### PR TITLE
Add watchdog for stale weather data

### DIFF
--- a/src/settings.toml.default
+++ b/src/settings.toml.default
@@ -21,4 +21,8 @@ OWM_API_TOKEN="Your Token"
 OWM_ZIP="zip/post code"
 OWM_COUNTRY="US" # Please use ISO 3166 country codes
 # Set to 1 to enable using https:// urls
-OWM_USE_HTTPS=0 
+OWM_USE_HTTPS=0
+
+# seconds without a successful weather update before automatic restart.
+# Set to 0 or omit to use the built-in default (300 seconds).
+WEATHER_TIMEOUT=300


### PR DESCRIPTION
## Summary
- add optional WEATHER_TIMEOUT setting to restart device when weather updates stop
- switch clock intervals to monotonic time and guard weather updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8278f12c8328a8494351a49a1349