### PR TITLE
Fixed Pico Plus not having same alias for GP29.

### DIFF
--- a/src/light_sensor.py
+++ b/src/light_sensor.py
@@ -1,8 +1,8 @@
 import board
 from analogio import AnalogIn
 
-# Light sensor pin constant
-LS_PIN = board.GP26
+# NOTE: Pimoroni Pico Plus 2W maps the A0 pin to GP40 so we need to use the A0 alias to be portable across Pico boards.
+LS_PIN = board.A0
 
 class LightSensor:
     def __init__(self, settings) -> None:


### PR DESCRIPTION
Fixed by using alias A0 which is common across boards. 
This resolves #89 
